### PR TITLE
SQL improvements

### DIFF
--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -122,12 +122,12 @@ class SQL(object):
             self.logger.debug(statement)
 
             # if SELECT (or INSERT with RETURNING), return result set as list of dict objects
-            if re.search(r"^\s*SELECT\s+", statement, re.I):
+            if re.search(r"^\s*SELECT", statement, re.I):
                 rows = result.fetchall()
                 return [dict(row) for row in rows]
 
             # if INSERT, return primary key value for a newly inserted row
-            elif re.search(r"^\s*INSERT\s+", statement, re.I):
+            elif re.search(r"^\s*INSERT", statement, re.I):
                 if self.engine.url.get_backend_name() in ["postgres", "postgresql"]:
                     result = self.engine.execute(sqlalchemy.text("SELECT LASTVAL()"))
                     return result.first()[0]
@@ -135,7 +135,7 @@ class SQL(object):
                     return result.lastrowid
 
             # if DELETE or UPDATE, return number of rows matched
-            elif re.search(r"^\s*(?:DELETE|UPDATE)\s+", statement, re.I):
+            elif re.search(r"^\s*(?:DELETE|UPDATE)", statement, re.I):
                 return result.rowcount
 
             # if some other statement, return True unless exception

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -125,6 +125,7 @@ class SQL(object):
             if re.search(r"^\s*SELECT", statement, re.I):
 
                 # coerce any decimal.Decimal objects to float objects
+                # https://groups.google.com/d/msg/sqlalchemy/0qXMYJvq8SA/oqtvMD9Uw-kJ
                 rows = [dict(row) for row in result.fetchall()]
                 for row in rows:
                     for column in row:


### PR DESCRIPTION
In `psycopg2` driver, numeric columns are returned as `decimal.Decimal`, which is more precise than `float` but inconsistent with SQLite and, thus, some students' code. This PR pre-casts (lossily) `decimal.Decimals` to `floats`.

E.g., `execute("SELECT * FROM users")` might otherwise return:

```
[{'id': 1, 'username': 'foo', 'hash': 'bar', 'cash': Decimal('123.45')}]
```