### PR TITLE
added foreign key constraint support to SQLite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 before_script:
 - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
 - psql -c 'create database test;' -U postgres
-- touch test.db
+- touch test.db test1.db
 script: python tests/sql.py
 after_script: rm -f test.db
 jobs:

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     package_dir={"": "src"},
     packages=["cs50"],
     url="https://github.com/cs50/python-cs50",
-    version="2.4.0"
+    version="2.4.1"
 )

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -55,6 +55,7 @@ class SQL(object):
         # Log statements to standard error
         logging.basicConfig(level=logging.DEBUG)
         self.logger = logging.getLogger("cs50")
+        disabled = self.logger.disabled
 
         # Test database
         try:
@@ -65,7 +66,7 @@ class SQL(object):
             e.__cause__ = None
             raise e
         else:
-            self.logger.disabled = False
+            self.logger.disabled = disabled
 
     def _parse(self, e):
         """Parses an exception, returns its message."""

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -33,14 +33,15 @@ class SQL(object):
             if not os.path.isfile(matches.group(1)):
                 raise RuntimeError("not a file: {}".format(matches.group(1)))
 
-            foreign_keys_enabled = kwargs.pop("foreign_keys_enabled", False)
+            # Remember foreign_keys and remove it from kwargs
+            foreign_keys = kwargs.pop("foreign_keys", False)
 
             # Create engine, raising exception if back end's module not installed
             self.engine = sqlalchemy.create_engine(url, **kwargs)
 
-            # Whether to enable foreign key constraints
-            if foreign_keys_enabled:
-                sqlalchemy.event.listen(self.engine, "connect", _on_connect)
+            # Enable foreign key constraints
+            if foreign_keys:
+                sqlalchemy.event.listen(self.engine, "connect", _connect)
         else:
             # Create engine, raising exception if back end's module not installed
             self.engine = sqlalchemy.create_engine(url, **kwargs)
@@ -226,7 +227,7 @@ class SQL(object):
 
 
 # http://docs.sqlalchemy.org/en/latest/dialects/sqlite.html#foreign-key-support
-def _on_connect(dbapi_connection, connection_record):
+def _connect(dbapi_connection, connection_record):
     """Enables foreign key support."""
 
     # Ensure backend is sqlite

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -43,6 +43,7 @@ class SQL(object):
             if foreign_keys:
                 sqlalchemy.event.listen(self.engine, "connect", _connect)
         else:
+
             # Create engine, raising exception if back end's module not installed
             self.engine = sqlalchemy.create_engine(url, **kwargs)
 

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -146,6 +146,8 @@ class SQL(object):
                     return process(value)
 
         # Allow only one statement at a time
+        # SQLite does not support executing many statements
+        # https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.execute
         if len(sqlparse.split(text)) > 1:
             raise RuntimeError("too many statements at once")
 

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -33,13 +33,13 @@ class SQL(object):
             if not os.path.isfile(matches.group(1)):
                 raise RuntimeError("not a file: {}".format(matches.group(1)))
 
-            pragma_foreign_keys = kwargs.pop("pragma_foreign_keys", False)
+            foreign_keys_enabled = kwargs.pop("foreign_keys_enabled", False)
 
             # Create engine, raising exception if back end's module not installed
             self.engine = sqlalchemy.create_engine(url, **kwargs)
 
             # Whether to enable foreign key constraints
-            if pragma_foreign_keys:
+            if foreign_keys_enabled:
                 sqlalchemy.event.listen(self.engine, "connect", _on_connect)
         else:
             # Create engine, raising exception if back end's module not installed

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -107,12 +107,19 @@ class SQLiteTests(SQLTests):
     @classmethod
     def setUpClass(self):
         self.db = SQL("sqlite:///test.db")
+        self.db1 = SQL("sqlite:///test1.db", pragma_foreign_keys=True)
 
     def setUp(self):
         self.db.execute("CREATE TABLE cs50(id INTEGER PRIMARY KEY, val TEXT)")
 
-    def multi_inserts_enabled(self):
-        return False
+    def test_foreign_key_support(self):
+        self.db.execute("CREATE TABLE foo(id INTEGER PRIMARY KEY)")
+        self.db.execute("CREATE TABLE bar(foo_id INTEGER, FOREIGN KEY (foo_id) REFERENCES foo(id))")
+        self.assertEqual(self.db.execute("INSERT INTO bar VALUES(50)"), 1)
+
+        self.db1.execute("CREATE TABLE foo(id INTEGER PRIMARY KEY)")
+        self.db1.execute("CREATE TABLE bar(foo_id INTEGER, FOREIGN KEY (foo_id) REFERENCES foo(id))")
+        self.assertEqual(self.db1.execute("INSERT INTO bar VALUES(50)"), None)
 
 if __name__ == "__main__":
     suite = unittest.TestSuite([
@@ -120,5 +127,6 @@ if __name__ == "__main__":
         unittest.TestLoader().loadTestsFromTestCase(MySQLTests),
         unittest.TestLoader().loadTestsFromTestCase(PostgresTests)
     ])
-    logging.getLogger("cs50.sql").disabled = True
+
+    logging.getLogger("cs50").disabled = True
     sys.exit(not unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful())

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -107,7 +107,7 @@ class SQLiteTests(SQLTests):
     @classmethod
     def setUpClass(self):
         self.db = SQL("sqlite:///test.db")
-        self.db1 = SQL("sqlite:///test1.db", pragma_foreign_keys=True)
+        self.db1 = SQL("sqlite:///test1.db", foreign_keys_enabled=True)
 
     def setUp(self):
         self.db.execute("CREATE TABLE cs50(id INTEGER PRIMARY KEY, val TEXT)")

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -107,7 +107,7 @@ class SQLiteTests(SQLTests):
     @classmethod
     def setUpClass(self):
         self.db = SQL("sqlite:///test.db")
-        self.db1 = SQL("sqlite:///test1.db", foreign_keys_enabled=True)
+        self.db1 = SQL("sqlite:///test1.db", foreign_keys=True)
 
     def setUp(self):
         self.db.execute("CREATE TABLE cs50(id INTEGER PRIMARY KEY, val TEXT)")


### PR DESCRIPTION
@dmalan sqlite ignores foreign key constraints by default and they have to be enabled by hooking into the `connect` event per http://docs.sqlalchemy.org/en/latest/dialects/sqlite.html#foreign-key-support. This PR adds support for optionally respecting foreign key constraints. Users would just have to pass `foreign_keys_enabled=True` to `SQL`'s constructor.

As an aside this PR also restores the original value for `logger.disabled` after temporarily disabling it per 
89657ea.

Any thoughts?

PS, thanks to Wellington Rampazo who reported issues with foreign keys when using the library!