### PR TITLE
flags get_char as pending deprecation

### DIFF
--- a/src/cs50/__init__.py
+++ b/src/cs50/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 from .cs50 import eprint, get_char, get_float, get_int, get_string
 try:
@@ -7,6 +8,10 @@ except:
     pass
 
 from . import flask
+
+# Enable warnings
+warnings.filterwarnings("always", category=DeprecationWarning, module="^cs50\.")
+warnings.filterwarnings("always", category=PendingDeprecationWarning, module="^cs50\.")
 
 
 class CustomImporter(object):

--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -1,12 +1,13 @@
 from __future__ import print_function
 
-import inspect
 import re
 import sys
+import warnings
 
 from distutils.sysconfig import get_python_lib
+from inspect import getframeinfo, stack
 from os.path import abspath, join
-from termcolor import colored
+from termcolor import colored, cprint
 from traceback import extract_tb, format_list, format_exception_only, format_exception
 
 
@@ -39,8 +40,8 @@ def eprint(*args, **kwargs):
     """
     end = kwargs.get("end", "\n")
     sep = kwargs.get("sep", " ")
-    (filename, lineno) = inspect.stack()[1][1:3]
-    print("{}:{}: ".format(filename, lineno), end="")
+    caller = getframeinfo(stack()[1][0])
+    print("{}:{}: ".format(caller.filename, caller.lineno), end="")
     print(*args, end=end, file=sys.stderr, sep=sep)
 
 
@@ -76,6 +77,9 @@ def get_char(prompt=None):
     if text is not a single char, user is prompted to retry. If line can't
     be read, return None.
     """
+    caller = getframeinfo(stack()[1][0])
+    cprint(warnings.formatwarning("get_char will soon be deprecated, use get_string instead",
+                                  PendingDeprecationWarning, caller.filename, caller.lineno, line=""), "yellow", end="")
     while True:
         s = get_string(prompt)
         if s is None:

--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -6,7 +6,7 @@ from .cs50 import formatException
 # Try to monkey-patch Flask, if installed
 try:
 
-    # Only patch 0.12 (in case logging changes in 0.13)
+    # Only patch <= 0.12 (in case logging changes in 0.13)
     version = StrictVersion(get_distribution("flask").version)
     assert version >= StrictVersion("0.10") and version < StrictVersion("0.13")
 


### PR DESCRIPTION
Motivation is that Python has no `get_char`, so much like we don't support `get_long_long` in Python 2 or 3 or `get_long` in Python 3, `get_char` should similarly be phased out.