### PR TITLE
remove stdin wrapper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     package_dir={"": "src"},
     packages=["cs50"],
     url="https://github.com/cs50/python-cs50",
-    version="3.0.1"
+    version="3.0.2"
 )

--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -28,28 +28,7 @@ class flushfile():
         self.f.flush()
 
 
-class Reader:
-    """
-    Disable buffering for input() as well.
-
-    https://bugs.python.org/issue24402
-    """
-
-    def __init__(self, f):
-        self.f = f
-
-    def __getattr__(self, name):
-        return getattr(self.f, name)
-
-    def fileno():
-        raise OSError()
-
-    def read(self, size):
-        return self.f.read(size)
-
-
 sys.stderr = flushfile(sys.stderr)
-sys.stdin = Reader(sys.stdin)
 sys.stdout = flushfile(sys.stdout)
 
 


### PR DESCRIPTION
For some reason breaks passenger:

```
Traceback (most recent call last):
File "/var/lib/gems/2.5.0/gems/passenger-5.3.5/src/helper-scripts/wsgi-loader.py", line 391, in <module>
handler.main_loop()
File "/var/lib/gems/2.5.0/gems/passenger-5.3.5/src/helper-scripts/wsgi-loader.py", line 187, in main_loop
client, address = self.accept_connection()
File "/var/lib/gems/2.5.0/gems/passenger-5.3.5/src/helper-scripts/wsgi-loader.py", line 224, in accept_connection
result = select.select([self.owner_pipe, self.server.fileno()], [], [])[0]
TypeError: fileno() takes 0 positional arguments but 1 was given
```

Was originally added to fix #54 but that doesn't seem to be a problem in Python 3.7 at least.