### PR TITLE
Fix missing self arguments in Flask __init__ replacement

### DIFF
--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -49,8 +49,8 @@ try:
             import flask
             from werkzeug.middleware.proxy_fix import ProxyFix
             _before = flask.Flask.__init__
-            def _after(*args, **kwargs):
-                _before(*args, **kwargs)
+            def _after(self, *args, **kwargs):
+                _before(self, *args, **kwargs)
                 self.wsgi_app = ProxyFix(self.wsgi_app, x_proto=1)
             flask.Flask.__init__ = _after
         except:


### PR DESCRIPTION
Commit https://github.com/cs50/python-cs50/commit/32456853c0037673b85c2419557a2390f0cd0ef9 broke the CS50 Flask monkey-patch, due to a missing `self` argument when swapping the `__init__` functions of `flask.Flask` with both `_before` and `_after`. As such, they get `NameError: name 'self' is not defined` when running the app.

See https://www.reddit.com/r/cs50/comments/cbez89/finance_nameerror_name_self_is_not_defined/ to find users using the CS50 IDE facing issues with Flask.

This commit adds both `self` arguments into both `_before` and `_after`, fixing the issue.

This fix has been tested to work with pset7 similarities, and should fix the other psets that require the use of Flask as well.