### PR TITLE
Fix SQL error for pset8 finance

### DIFF
--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -31,16 +31,16 @@ try:
     except ImportError:
         pass
     else:
-        _before = SQL.execute
-        def _after(*args, **kwargs):
+        _before = SQL.SQL.execute
+        def _after(self, *args, **kwargs):
             disabled = logging.getLogger("cs50").disabled
             if flask.current_app:
                 logging.getLogger("cs50").disabled = False
             try:
-                return _before(*args, **kwargs)
+                return _before(self, *args, **kwargs)
             finally:
                 logging.getLogger("cs50").disabled = disabled
-        SQL.execute = _after
+        SQL.SQL.execute = _after
 
     # When behind CS50 IDE's proxy, ensure that flask.redirect doesn't redirect from HTTPS to HTTP
     # https://werkzeug.palletsprojects.com/en/0.15.x/middleware/proxy_fix/#module-werkzeug.middleware.proxy_fix

--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -31,16 +31,16 @@ try:
     except ImportError:
         pass
     else:
-        _before = SQL.SQL.execute
-        def _after(self, *args, **kwargs):
+        _sql_before = SQL.execute
+        def _sql_after(self, *args, **kwargs):
             disabled = logging.getLogger("cs50").disabled
             if flask.current_app:
                 logging.getLogger("cs50").disabled = False
             try:
-                return _before(self, *args, **kwargs)
+                return _sql_before(self, *args, **kwargs)
             finally:
                 logging.getLogger("cs50").disabled = disabled
-        SQL.SQL.execute = _after
+        SQL.execute = _sql_after
 
     # When behind CS50 IDE's proxy, ensure that flask.redirect doesn't redirect from HTTPS to HTTP
     # https://werkzeug.palletsprojects.com/en/0.15.x/middleware/proxy_fix/#module-werkzeug.middleware.proxy_fix
@@ -48,11 +48,11 @@ try:
         try:
             import flask
             from werkzeug.middleware.proxy_fix import ProxyFix
-            _before = flask.Flask.__init__
-            def _after(self, *args, **kwargs):
-                _before(self, *args, **kwargs)
+            _flask_before = flask.Flask.__init__
+            def _flask_after(self, *args, **kwargs):
+                _flask_before(self, *args, **kwargs)
                 self.wsgi_app = ProxyFix(self.wsgi_app, x_proto=1)
-            flask.Flask.__init__ = _after
+            flask.Flask.__init__ = _flask_after
         except:
             pass
 


### PR DESCRIPTION
After #83, users were facing errors with the CS50 SQL module with pset8 finance. The error occurs whenever the webserver is started and somebody visits the page. https://www.reddit.com/r/cs50/comments/cbez89/finance_nameerror_name_self_is_not_defined/etfi05q/

```
Traceback (most recent call last):
File "/usr/local/lib/python3.7/site-packages/werkzeug/serving.py", line 303, in run_wsgi
execute(self.server.app)
File "/usr/local/lib/python3.7/site-packages/werkzeug/serving.py", line 291, in execute
application_iter = app(environ, start_response)
File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
raise value
File "/home/ubuntu/2019/pset8/finance/application.py", line 36, in <module>
db = SQL("sqlite:///finance.db")
File "/usr/local/lib/python3.7/site-packages/cs50/sql.py", line 66, in __init__
self.execute("SELECT 1")
File "/usr/local/lib/python3.7/site-packages/cs50/flask.py", line 40, in _after
return _before(*args, **kwargs)
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 423, in __init__
instance_path = self.auto_find_instance_path()
AttributeError: 'SQL' object has no attribute 'auto_find_instance_path'
```

This is due to the monkey-patch swapping the `SQL.SQL.execute` function wrongly. This PR fixes that bug.

Tested with running pset8 finance.