### PR TITLE
lazily imports more modules for performance

### DIFF
--- a/src/cs50/__init__.py
+++ b/src/cs50/__init__.py
@@ -1,6 +1,28 @@
 import os
 import sys
 
+
+class CustomImporter(object):
+    """
+    Import cs50.SQL lazily for performance (and so that rest of library can be used without SQLAlchemy installed).
+    https://docs.python.org/3/library/imp.html
+    http://xion.org.pl/2012/05/06/hacking-python-imports/
+    http://dangerontheranger.blogspot.com/2012/07/how-to-use-sysmetapath-with-python.html
+    """
+
+    def find_module(self, fullname, path=None):
+        if fullname == "cs50.SQL":
+            return self
+        return None
+
+    def load_module(self, name):
+        if name in sys.modules:
+            return sys.modules[name]
+        from .sql import SQL
+        sys.modules[name] = SQL
+        return SQL
+
+
 try:
 
     # Save student's sys.path
@@ -19,8 +41,8 @@ try:
     # Replace Flask's logger
     from . import flask
 
-    # Wrap SQLAlchemy
-    from .sql import SQL
+    # Lazily load CS50.SQL
+    sys.meta_path.append(CustomImporter())
 
 finally:
 

--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -1,7 +1,6 @@
 import logging
 
 from distutils.version import StrictVersion
-from os import getenv
 from pkg_resources import get_distribution
 
 from .cs50 import _formatException
@@ -44,6 +43,7 @@ try:
 
     # When behind CS50 IDE's proxy, ensure that flask.redirect doesn't redirect from HTTPS to HTTP
     # https://werkzeug.palletsprojects.com/en/0.15.x/middleware/proxy_fix/#module-werkzeug.middleware.proxy_fix
+    from os import getenv
     if getenv("CS50_IDE_TYPE") == "online":
         try:
             import flask

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -286,6 +286,8 @@ class SQL(object):
 
             # Lazily import
             import datetime
+            import sqlalchemy
+            import sqlparse
 
             # bool
             if type(value) is bool:
@@ -355,6 +357,9 @@ class SQL(object):
 def _parse_exception(e):
     """Parses an exception, returns its message."""
 
+    # Lazily import
+    import re
+
     # MySQL
     matches = re.search(r"^\(_mysql_exceptions\.OperationalError\) \(\d+, \"(.+)\"\)$", str(e))
     if matches:
@@ -376,6 +381,10 @@ def _parse_exception(e):
 
 def _parse_placeholder(token):
     """Infers paramstyle, name from sqlparse.tokens.Name.Placeholder."""
+
+    # Lazily load
+    import re
+    import sqlparse
 
     # Validate token
     if not isinstance(token, sqlparse.sql.Token) or token.ttype != sqlparse.tokens.Name.Placeholder:

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -283,7 +283,7 @@ class SQL(object):
         """
 
         # Lazily import
-        import sqlalchemy
+        import sqlparse
 
         def __escape(value):
 

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -69,6 +69,7 @@ class SQL(object):
 
         # Lazily import
         import decimal
+        import sqlalchemy
         import sqlparse
         import termcolor
         import warnings

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -282,12 +282,14 @@ class SQL(object):
         https://docs.sqlalchemy.org/en/latest/core/type_api.html#sqlalchemy.types.TypeEngine.literal_processor
         """
 
+        # Lazily import
+        import sqlalchemy
+
         def __escape(value):
 
             # Lazily import
             import datetime
             import sqlalchemy
-            import sqlparse
 
             # bool
             if type(value) is bool:

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -1,17 +1,3 @@
-import datetime
-import decimal
-import importlib
-import logging
-import os
-import re
-import sqlalchemy
-import sqlite3
-import sqlparse
-import sys
-import termcolor
-import warnings
-
-
 class SQL(object):
     """Wrap SQLAlchemy to provide a simple SQL API."""
 
@@ -24,6 +10,13 @@ class SQL(object):
         http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
         http://docs.sqlalchemy.org/en/latest/dialects/index.html
         """
+
+        # Lazily import
+        import logging
+        import os
+        import re
+        import sqlalchemy
+        import sqlite3
 
         # Get logger
         self._logger = logging.getLogger("cs50")
@@ -73,6 +66,12 @@ class SQL(object):
 
     def execute(self, sql, *args, **kwargs):
         """Execute a SQL statement."""
+
+        # Lazily import
+        import decimal
+        import sqlparse
+        import termcolor
+        import warnings
 
         # Allow only one statement at a time, since SQLite doesn't support multiple
         # https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.execute
@@ -217,7 +216,7 @@ class SQL(object):
 
         # Catch SQLAlchemy warnings
         with warnings.catch_warnings():
-            
+
             # Raise exceptions for warnings
             warnings.simplefilter("error")
 
@@ -283,6 +282,9 @@ class SQL(object):
         """
 
         def __escape(value):
+
+            # Lazily import
+            import datetime
 
             # bool
             if type(value) is bool:

--- a/tests/python.py
+++ b/tests/python.py
@@ -4,5 +4,5 @@ sys.path.insert(0, "../src")
 
 import cs50
 
-i = cs50.get_int()
-print(i)
+i = cs50.get_int("Input:  ")
+print(f"Output: {i}")


### PR DESCRIPTION
Improves performance of using just `get_*` by lazily loading more of `SQL` and `Flask`.  E.g., on a recent MBP, reduced performance of

```
import cs50

i = cs50.get_int()
print(i)
```

from ~500ms to ~300ms.

Cf. https://wiki.python.org/moin/PythonSpeed/PerformanceTips#Import_Statement_Overhead

We could alternatively break a deliberate abstraction barrier and hardcode awareness of / support for Flask inside of `SQL`, which might further delay expensive imports.