### PR TITLE
Register flask.current_app.teardown_appcontext only once

### DIFF
--- a/tests/flask/application.py
+++ b/tests/flask/application.py
@@ -9,7 +9,7 @@ import cs50.flask
 
 app = Flask(__name__)
 
-db = cs50.SQL("sqlite:///../sqlite.db")
+db = cs50.SQL("sqlite:///../test.db")
 
 @app.route("/")
 def index():


### PR DESCRIPTION
SQL update: only register the shutdown_session function once to the Flask teardown_appcontext_funcs. Checks existing teardown functions before registering it.