### PR TITLE
Transaction sessions; appcontext teardown fix; multiple databases in request fix.

### DIFF
--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -43,6 +43,7 @@ class SQL(object):
         import os
         import re
         import sqlalchemy
+        import sqlalchemy.orm as orm
         import sqlite3
 
         # Get logger
@@ -56,8 +57,15 @@ class SQL(object):
             if not os.path.isfile(matches.group(1)):
                 raise RuntimeError("not a file: {}".format(matches.group(1)))
 
+        # Record the URL (used in testing)
+        self.url = url
+
         # Create engine, disabling SQLAlchemy's own autocommit mode, raising exception if back end's module not installed
         self._engine = sqlalchemy.create_engine(url, **kwargs).execution_options(autocommit=False)
+
+        # Create a variable to hold the session. If None, autocommit is on.
+        self.Session = orm.sessionmaker(bind=self._engine)
+        self._session = None
 
         # Listener for connections
         def connect(dbapi_connection, connection_record):
@@ -90,9 +98,9 @@ class SQL(object):
             self._logger.disabled = disabled
 
     def __del__(self):
-        """Close database connection."""
-        if hasattr(self, "_connection"):
-            self._connection.close()
+        """Close database session and connection."""
+        if self._session is not None:
+            self._session.close()
 
     @_enable_logging
     def execute(self, sql, *args, **kwargs):
@@ -125,6 +133,12 @@ class SQL(object):
             if token.ttype in [sqlparse.tokens.Keyword.DDL, sqlparse.tokens.Keyword.DML]:
                 command = token.value.upper()
                 break
+
+            # Begin a new transaction session, if done manually
+            elif token.value.upper() in ["BEGIN", "START"]:
+                if self._session is not None:
+                    self._session.close()
+                self._session = self.Session()
         else:
             command = None
 
@@ -272,6 +286,11 @@ class SQL(object):
         statement = "".join([str(token) for token in tokens])
 
         # Connect to database (for transactions' sake)
+        session = self._session
+        if session is None:
+            session = self.Session()
+
+        # Set up a Flask app teardown function to close session at teardown
         try:
 
             # Infer whether Flask is installed
@@ -280,29 +299,18 @@ class SQL(object):
             # Infer whether app is defined
             assert flask.current_app
 
-            # If no connection for app's current request yet
-            if not hasattr(flask.g, "_connection"):
+            # Disconnect later - but only once
+            if not hasattr(self, "teardown_appcontext_added"):
+                self.teardown_appcontext_added = True
 
-                # Connect now
-                flask.g._connection = self._engine.connect()
-
-                # Disconnect later
+                # Register shutdown_session on app context teardown
                 @flask.current_app.teardown_appcontext
                 def shutdown_session(exception=None):
-                    if hasattr(flask.g, "_connection"):
-                        flask.g._connection.close()
-
-            # Use this connection
-            connection = flask.g._connection
+                    if self._session is not None:
+                        self._session.close()
 
         except (ModuleNotFoundError, AssertionError):
-
-            # If no connection yet
-            if not hasattr(self, "_connection"):
-                self._connection = self._engine.connect()
-
-            # Use this connection
-            connection = self._connection
+            pass
 
         # Catch SQLAlchemy warnings
         with warnings.catch_warnings():
@@ -317,7 +325,7 @@ class SQL(object):
                 _statement = "".join([str(bytes) if token.ttype == sqlparse.tokens.Other else str(token) for token in tokens])
 
                 # Execute statement
-                result = connection.execute(sqlalchemy.text(statement))
+                result = session.execute(sqlalchemy.text(statement))
 
                 # Return value
                 ret = True
@@ -346,7 +354,7 @@ class SQL(object):
                 elif command == "INSERT":
                     if self._engine.url.get_backend_name() in ["postgres", "postgresql"]:
                         try:
-                            result = connection.execute("SELECT LASTVAL()")
+                            result = session.execute("SELECT LASTVAL()")
                             ret = result.first()[0]
                         except sqlalchemy.exc.OperationalError:  # If lastval is not yet defined in this session
                             ret = None
@@ -356,6 +364,18 @@ class SQL(object):
                 # If DELETE or UPDATE, return number of rows matched
                 elif command in ["DELETE", "UPDATE"]:
                     ret = result.rowcount
+
+                # If COMMIT or ROLLBACK, turn on autocommit mode
+                elif command in ["COMMIT", "ROLLBACK"] and "TO" not in statement:
+                    session.close()
+                    self._session = None
+
+
+                # If autocommit is on, commit and close
+                if self._session is None and command not in ["COMMIT", "ROLLBACK"]:
+                    if command not in ["SELECT"]:
+                        session.commit()
+                    session.close()
 
             # If constraint violated, return None
             except sqlalchemy.exc.IntegrityError as e:

--- a/tests/flask/application.py
+++ b/tests/flask/application.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import requests
 import sys
 from flask import Flask, render_template
@@ -9,14 +11,64 @@ import cs50.flask
 
 app = Flask(__name__)
 
-db = cs50.SQL("sqlite:///../sqlite.db")
+logging.disable(logging.CRITICAL)
+os.environ["WERKZEUG_RUN_MAIN"] = "true"
+
+db = cs50.SQL("sqlite:///../test.db")
 
 @app.route("/")
 def index():
-    db.execute("SELECT 1")
     """
     def f():
         res = requests.get("cs50.harvard.edu")
     f()
     """
     return render_template("index.html")
+
+@app.route("/autocommit")
+def autocommit():
+    db.execute("INSERT INTO test (val) VALUES (?)", "def")
+    db2 = cs50.SQL(db.url)
+    ret = db2.execute("SELECT val FROM test WHERE val=?", "def")
+    return str(ret == [{"val": "def"}])
+
+@app.route("/create")
+def create():
+    ret = db.execute("CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT, val VARCHAR(16))")
+    return str(ret)
+
+@app.route("/delete")
+def delete():
+    ret = db.execute("DELETE FROM test")
+    return str(ret > 0)
+
+@app.route("/drop")
+def drop():
+    ret = db.execute("DROP TABLE test")
+    return str(ret)
+
+@app.route("/insert")
+def insert():
+    ret = db.execute("INSERT INTO test (val) VALUES (?)", "abc")
+    return str(ret > 0)
+
+@app.route("/multiple_connections")
+def multiple_connections():
+    ctx = len(app.teardown_appcontext_funcs)
+    db1 = cs50.SQL(db.url)
+    td1 = (len(app.teardown_appcontext_funcs) == ctx + 1)
+    db2 = cs50.SQL(db.url)
+    td2 = (len(app.teardown_appcontext_funcs) == ctx + 2)
+    return str(td1 and td2)
+
+@app.route("/select")
+def select():
+    ret = db.execute("SELECT val FROM test")
+    return str(ret == [{"val": "abc"}])
+
+@app.route("/single_teardown")
+def single_teardown():
+    db.execute("SELECT * FROM test")
+    ctx = len(app.teardown_appcontext_funcs)
+    db.execute("SELECT COUNT(id) FROM test")
+    return str(ctx == len(app.teardown_appcontext_funcs))

--- a/tests/flask/application.py
+++ b/tests/flask/application.py
@@ -2,19 +2,21 @@ import logging
 import os
 import requests
 import sys
-from flask import Flask, render_template
 
 sys.path.insert(0, "../../src")
 
 import cs50
 import cs50.flask
 
+from flask import Flask, render_template
+
 app = Flask(__name__)
 
 logging.disable(logging.CRITICAL)
 os.environ["WERKZEUG_RUN_MAIN"] = "true"
 
-db = cs50.SQL("sqlite:///../test.db")
+db_url = "sqlite:///../test.db"
+db = cs50.SQL(db_url)
 
 @app.route("/")
 def index():
@@ -28,7 +30,7 @@ def index():
 @app.route("/autocommit")
 def autocommit():
     db.execute("INSERT INTO test (val) VALUES (?)", "def")
-    db2 = cs50.SQL(db.url)
+    db2 = cs50.SQL(db_url)
     ret = db2.execute("SELECT val FROM test WHERE val=?", "def")
     return str(ret == [{"val": "def"}])
 
@@ -55,9 +57,9 @@ def insert():
 @app.route("/multiple_connections")
 def multiple_connections():
     ctx = len(app.teardown_appcontext_funcs)
-    db1 = cs50.SQL(db.url)
+    db1 = cs50.SQL(db_url)
     td1 = (len(app.teardown_appcontext_funcs) == ctx + 1)
-    db2 = cs50.SQL(db.url)
+    db2 = cs50.SQL(db_url)
     td2 = (len(app.teardown_appcontext_funcs) == ctx + 2)
     return str(td1 and td2)
 

--- a/tests/flask/test.py
+++ b/tests/flask/test.py
@@ -1,0 +1,49 @@
+from application import app
+import logging
+import requests
+import sys
+import threading
+import time
+import unittest
+
+
+def request(route):
+    r = requests.get("http://localhost:5000/{}".format(route))
+    return r.text == "True"
+
+class FlaskTests(unittest.TestCase):
+
+    def test__create(self):
+        self.assertTrue(request("create"))
+ 
+    def test_autocommit(self):
+        self.assertTrue(request("autocommit"))
+
+    def test_delete(self):
+        self.assertTrue(request("delete"))
+
+    def test_insert(self):
+        self.assertTrue(request("insert"))
+
+    def test_multiple_connections(self):
+        self.assertTrue(request("multiple_connections"))
+
+    def test_select(self):
+        self.assertTrue(request("select"))
+
+    def test_single_teardown(self):
+        self.assertTrue(request("single_teardown"))
+
+    def test_zdrop(self):
+        self.assertTrue(request("drop"))
+
+
+if __name__ == "__main__":
+    t = threading.Thread(target=app.run, daemon=True)
+    t.start()
+
+    suite = unittest.TestSuite([
+        unittest.TestLoader().loadTestsFromTestCase(FlaskTests)
+    ])
+
+    sys.exit(not unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful())

--- a/tests/flask/test.py
+++ b/tests/flask/test.py
@@ -1,4 +1,3 @@
-from application import app
 import logging
 import requests
 import sys
@@ -6,6 +5,7 @@ import threading
 import time
 import unittest
 
+from application import app
 
 def request(route):
     r = requests.get("http://localhost:5000/{}".format(route))

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -123,6 +123,12 @@ class SQLTests(unittest.TestCase):
         db2 = SQL(self.db_url)
         self.assertEqual(db2.execute("DELETE FROM cs50 WHERE id < 3"), 2)
 
+    def test_commit_no_transaction(self):
+        with self.assertRaises(RuntimeError):
+            self.db.execute("COMMIT")
+        with self.assertRaises(RuntimeError):
+            self.db.execute("ROLLBACK")
+
     def test_commit(self):
         self.db.execute("BEGIN")
         self.db.execute("INSERT INTO cs50 (val) VALUES('foo')")
@@ -131,6 +137,12 @@ class SQLTests(unittest.TestCase):
         # Load a new database instance to confirm the INSERT was committed
         db2 = SQL(self.db_url)
         self.assertEqual(db2.execute("SELECT val FROM cs50"), [{"val": "foo"}])
+
+    def test_double_begin(self):
+        self.db.execute("BEGIN")
+        with self.assertRaises(RuntimeError):
+            self.db.execute("BEGIN")
+        self.db.execute("ROLLBACK")
 
     def test_rollback(self):
         self.db.execute("BEGIN")
@@ -177,7 +189,7 @@ class MySQLTests(SQLTests):
 class PostgresTests(SQLTests):
     @classmethod
     def setUpClass(self):
-        self.db_url = "postgresql://postgres@localhost/test"
+        self.db_url = "postgresql://root:test@localhost/test"
         self.db = SQL(self.db_url)
         print("\nPOSTGRES tests")
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -189,7 +189,7 @@ class MySQLTests(SQLTests):
 class PostgresTests(SQLTests):
     @classmethod
     def setUpClass(self):
-        self.db_url = "postgresql://root:test@localhost/test"
+        self.db_url = "postgresql://postgres@localhost/test"
         self.db = SQL(self.db_url)
         print("\nPOSTGRES tests")
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -177,7 +177,7 @@ class MySQLTests(SQLTests):
 class PostgresTests(SQLTests):
     @classmethod
     def setUpClass(self):
-        self.db_url = "postgresql://root:test@localhost/test"
+        self.db_url = "postgresql://postgres@localhost/test"
         self.db = SQL(self.db_url)
         print("\nPOSTGRES tests")
 

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -120,7 +120,7 @@ class SQLTests(unittest.TestCase):
         self.assertEqual(self.db.execute("INSERT INTO cs50(val) VALUES('bar')"), 2)
 
         # Load a new database instance to confirm the INSERTs were committed
-        db2 = SQL(self.db.url)
+        db2 = SQL(self.db_url)
         self.assertEqual(db2.execute("DELETE FROM cs50 WHERE id < 3"), 2)
 
     def test_commit(self):
@@ -129,7 +129,7 @@ class SQLTests(unittest.TestCase):
         self.db.execute("COMMIT")
 
         # Load a new database instance to confirm the INSERT was committed
-        db2 = SQL(self.db.url)
+        db2 = SQL(self.db_url)
         self.assertEqual(db2.execute("SELECT val FROM cs50"), [{"val": "foo"}])
 
     def test_rollback(self):
@@ -167,7 +167,8 @@ class SQLTests(unittest.TestCase):
 class MySQLTests(SQLTests):
     @classmethod
     def setUpClass(self):
-        self.db = SQL("mysql://root@localhost/test")
+        self.db_url = "mysql://root@localhost/test"
+        self.db = SQL(self.db_url)
         print("\nMySQL tests")
 
     def setUp(self):
@@ -176,7 +177,8 @@ class MySQLTests(SQLTests):
 class PostgresTests(SQLTests):
     @classmethod
     def setUpClass(self):
-        self.db = SQL("postgresql://root:test@localhost/test")
+        self.db_url = "postgresql://root:test@localhost/test"
+        self.db = SQL(self.db_url)
         print("\nPOSTGRES tests")
 
     def setUp(self):
@@ -189,7 +191,8 @@ class SQLiteTests(SQLTests):
     @classmethod
     def setUpClass(self):
         open("test.db", "w").close()
-        self.db = SQL("sqlite:///test.db")
+        self.db_url = "sqlite:///test.db"
+        self.db = SQL(self.db_url)
         print("\nSQLite tests")
 
     def setUp(self):


### PR DESCRIPTION
Use sessions to handle transactions, allowing for both auto and manual commit modes. Registers Flask appcontext teardown function only once per database instance, and also allows for multiple database connections in a single Flask request.

Add unit tests for SQL savepoints, autocommit mode, manual transaction mode. Add integration tests for Flask.