### PR TITLE
configure root logger

### DIFF
--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -22,6 +22,21 @@ try:
 except IndexError:
     pass
 
+# Configure cs50 logger
+_logger = logging.getLogger("cs50")
+_logger.setLevel(logging.DEBUG)
+
+# Log messages once
+_logger.propagate = False
+
+handler = logging.StreamHandler()
+handler.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter("%(levelname)s: %(message)s")
+formatter.formatException = lambda exc_info: _formatException(*exc_info)
+handler.setFormatter(formatter)
+_logger.addHandler(handler)
+
 
 class _flushfile():
     """

--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -15,8 +15,11 @@ from traceback import format_exception
 # Configure default logging handler and formatter
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
 
-# Patch formatException
-logging.root.handlers[0].formatter.formatException = lambda exc_info: _formatException(*exc_info)
+try:
+    # Patch formatException
+    logging.root.handlers[0].formatter.formatException = lambda exc_info: _formatException(*exc_info)
+except IndexError:
+    pass
 
 
 class _flushfile():

--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import inspect
+import logging
 import os
 import re
 import sys
@@ -9,6 +10,13 @@ from distutils.sysconfig import get_python_lib
 from os.path import abspath, join
 from termcolor import colored
 from traceback import format_exception
+
+
+# Configure default logging handler and formatter
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
+
+# Patch formatException
+logging.root.handlers[0].formatter.formatException = lambda exc_info: _formatException(*exc_info)
 
 
 class _flushfile():

--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -13,6 +13,7 @@ from traceback import format_exception
 
 
 # Configure default logging handler and formatter
+# Prevent flask, werkzeug, etc from adding default handler
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
 
 try:

--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -12,8 +12,6 @@ def _wrap_flask(f):
     if f.__version__ < StrictVersion("1.0"):
         return
 
-    f.logging.default_handler.formatter.formatException = lambda exc_info: _formatException(*exc_info)
-
     if os.getenv("CS50_IDE_TYPE") == "online":
         from werkzeug.middleware.proxy_fix import ProxyFix
         _flask_init_before = f.Flask.__init__

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -1,3 +1,30 @@
+def _enable_logging(f):
+    """Enable logging of SQL statements when Flask is in use."""
+
+    import logging
+    import functools
+
+    @functools.wraps(f)
+    def decorator(*args, **kwargs):
+
+        # Infer whether Flask is installed
+        try:
+            import flask
+        except ModuleNotFoundError:
+            return f(*args, **kwargs)
+
+        # Enable logging
+        disabled = logging.getLogger("cs50").disabled
+        if flask.current_app:
+            logging.getLogger("cs50").disabled = False
+        try:
+            return f(*args, **kwargs)
+        finally:
+            logging.getLogger("cs50").disabled = disabled
+
+    return decorator
+
+
 class SQL(object):
     """Wrap SQLAlchemy to provide a simple SQL API."""
 
@@ -73,6 +100,7 @@ class SQL(object):
             self._connection.close()
             delattr(self, "_connection")
 
+    @_enable_logging
     def execute(self, sql, *args, **kwargs):
         """Execute a SQL statement."""
 

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -4,7 +4,7 @@ from .cs50 import _formatException
 
 
 # Configure logger
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger("cs50")
 _logger.setLevel(logging.DEBUG)
 
 # Log messages once

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -10,13 +10,13 @@ _logger.setLevel(logging.DEBUG)
 # Log messages once
 _logger.propagate = False
 
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setLevel(logging.DEBUG)
 
 formatter = logging.Formatter("%(levelname)s: %(message)s")
 formatter.formatException = lambda exc_info: _formatException(*exc_info)
-ch.setFormatter(formatter)
-_logger.addHandler(ch)
+handler.setFormatter(formatter)
+_logger.addHandler(handler)
 
 
 class SQL(object):


### PR DESCRIPTION
When instantiating `cs50.SQL`, `logging.basicConfig` is called. It adds a handler on the root logger, if one doesn't exist, which causes flask to not add its own default handler, in which case our `_formatException` isn't used. To replicate:

```
from cs50 import SQL
from flask import Flask

app = Flask(__name__)
# db = SQL('sqlite:///foo.db')

@app.route('/')
def index():
  raise Exception() # highlighted in yellow
```

```
from cs50 import SQL
from flask import Flask

app = Flask(__name__)
db = SQL('sqlite:///foo.db')

@app.route('/')
def index():
  raise Exception() # not highlighted in yellow
```

There's a couple of ways to fix this. One way is to add a handler to the root logger before flask's `app.logger` is accessed per https://flask.palletsprojects.com/en/1.1.x/logging/#basic-configuration so that flask doesn't add its own handler. This PR does that by calling `logging.basicConfig` to add a default handler to the root logger and patches `formatException` on this handler's formatter. As a result, flask's formatter isn't used, so we don't need to patch its `formatException`.