### PR TITLE
avoid uppercasing identifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     package_dir={"": "src"},
     packages=["cs50"],
     url="https://github.com/cs50/python-cs50",
-    version="6.0.3"
+    version="6.0.4"
 )

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -114,7 +114,7 @@ class SQL(object):
         import warnings
 
         # Parse statement, stripping comments and then leading/trailing whitespace
-        statements = sqlparse.parse(sqlparse.format(sql, keyword_case="upper", strip_comments=True).strip())
+        statements = sqlparse.parse(sqlparse.format(sql, strip_comments=True).strip())
 
         # Allow only one statement at a time, since SQLite doesn't support multiple
         # https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.execute
@@ -130,8 +130,9 @@ class SQL(object):
         # Infer command from (unflattened) statement
         for token in statements[0]:
             if token.ttype in [sqlparse.tokens.Keyword, sqlparse.tokens.Keyword.DDL, sqlparse.tokens.Keyword.DML]:
-                if token.value in ["BEGIN", "DELETE", "INSERT", "SELECT", "START", "UPDATE"]:
-                    command = token.value
+                token_value = token.value.upper()
+                if token_value in ["BEGIN", "DELETE", "INSERT", "SELECT", "START", "UPDATE"]:
+                    command = token_value
                     break
         else:
             command = None

--- a/tests/sql.py
+++ b/tests/sql.py
@@ -129,6 +129,9 @@ class SQLTests(unittest.TestCase):
         self.db.execute("ROLLBACK")
         self.assertEqual(self.db.execute("SELECT val FROM cs50"), [])
 
+    def test_identifier_case(self):
+        self.assertIn("count", self.db.execute("SELECT 1 AS count")[0])
+
     def tearDown(self):
         self.db.execute("DROP TABLE cs50")
         self.db.execute("DROP TABLE IF EXISTS foo")


### PR DESCRIPTION
There is a bug in `sqlparse` where passing `keyword_case="upper"` to `sqlparse.format` causes it to uppercase any instances of keyword, even when used as an identifier rather than a keyword. For example:

```
SELECT 1 AS count;
```

would end up executing:

```
SELECT 1 AS COUNT;
```

This PR removes `keyword_case` for now.