### PR TITLE
Load sqlite module only if sqlite connection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     package_dir={"": "src"},
     packages=["cs50"],
     url="https://github.com/cs50/python-cs50",
-    version="9.2.2"
+    version="9.2.3"
 )

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -51,12 +51,12 @@ class SQL(object):
         import re
         import sqlalchemy
         import sqlalchemy.orm
-        import sqlite3
         import threading
 
         # Require that file already exist for SQLite
         matches = re.search(r"^sqlite:///(.+)$", url)
         if matches:
+            import sqlite3
             if not os.path.exists(matches.group(1)):
                 raise RuntimeError("does not exist: {}".format(matches.group(1)))
             if not os.path.isfile(matches.group(1)):

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 
 # Thread-local data
@@ -74,7 +75,7 @@ class SQL(object):
         def connect(dbapi_connection, connection_record):
 
             # Enable foreign key constraints
-            if 'sqlite3' in sys.modules and type(dbapi_connection) is sqlite3.Connection:  # If back end is sqlite
+            if "sqlite3" in sys.modules and type(dbapi_connection) is sqlite3.Connection:  # If back end is sqlite
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA foreign_keys=ON")
                 cursor.close()

--- a/src/cs50/sql.py
+++ b/src/cs50/sql.py
@@ -74,7 +74,7 @@ class SQL(object):
         def connect(dbapi_connection, connection_record):
 
             # Enable foreign key constraints
-            if type(dbapi_connection) is sqlite3.Connection:  # If back end is sqlite
+            if 'sqlite3' in sys.modules and type(dbapi_connection) is sqlite3.Connection:  # If back end is sqlite
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA foreign_keys=ON")
                 cursor.close()


### PR DESCRIPTION
Attempt to only load the `sqlite3` module if the database connection string is for a sqlite database.

This should help with issues loading the sqlite3 module in an environment where this is not available and not needed because using a different database connection type.