### PR TITLE
Fix method delegation in `_flushfile`

### DIFF
--- a/src/cs50/cs50.py
+++ b/src/cs50/cs50.py
@@ -49,7 +49,7 @@ class _flushfile():
         self.f = f
 
     def __getattr__(self, name):
-        return object.__getattribute__(self.f, name)
+        return getattr(self.f, name)
 
     def write(self, x):
         self.f.write(x)


### PR DESCRIPTION
The change is required when the stream to be wrapped is already a wrapper over the original std-stream and the wrapper also uses method delegation via `__getattr__`.

I discovered this issue when investigating https://github.com/thonny/thonny/issues/2924

Thonny IDE [fakes the standard streams](https://github.com/thonny/thonny/blob/9f5bd8c339842d78f55de5a28f36fa94317bf4fb/thonny/plugins/cpython_backend/cp_back.py#L1091) before running the code using cs05, which tries to add another wrapper over these faked streams. The problem is that cs50's `object.__getattribute__(self.f, name)` only sees the methods defined directly in Thonny's FakeStream and does not consider the methods available via `__getattr__`.

The built-in `getattr` proposed in this PR is able to look deeper.

For extra confidence you could investigate this SO answer, which also uses getattr: https://stackoverflow.com/a/107717/261181