### PR TITLE
flask.py: replace pkgutil with importlib

### DIFF
--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -37,7 +37,7 @@ if "flask" in sys.modules:
 # If Flask wasn't imported
 else:
     spec = importlib.util.find_spec("flask")
-    if spec.loader:
+    if spec and spec.loader:
         _exec_module_before = spec.loader.exec_module
 
         def _exec_module_after(*args, **kwargs):

--- a/src/cs50/flask.py
+++ b/src/cs50/flask.py
@@ -1,5 +1,5 @@
 import os
-import pkgutil
+import importlib.util
 import sys
 
 
@@ -36,12 +36,12 @@ if "flask" in sys.modules:
 
 # If Flask wasn't imported
 else:
-    flask_loader = pkgutil.get_loader("flask")
-    if flask_loader:
-        _exec_module_before = flask_loader.exec_module
+    spec = importlib.util.find_spec("flask")
+    if spec.loader:
+        _exec_module_before = spec.loader.exec_module
 
         def _exec_module_after(*args, **kwargs):
             _exec_module_before(*args, **kwargs)
             _wrap_flask(sys.modules["flask"])
 
-        flask_loader.exec_module = _exec_module_after
+        spec.loader.exec_module = _exec_module_after


### PR DESCRIPTION
pkgutil was removed after being deprecated since 3.12

https://docs.python.org/3/whatsnew/3.14.html#pkgutil

Also, @rongxin-liu could you make another tagged release? This package currently fails to build for us in Nixpkgs because of the 3.14 pkgutil removal https://hydra.nixos.org/build/317921017

if you make a tagged release we can update it in Nixpkgs and ship the fix to our users. 

Thanks!